### PR TITLE
dependencies: add missing dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,3 +11,7 @@ RoxygenNote: 7.2.3
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Imports: 
+    dplyr,
+    RCurl,
+    rvest


### PR DESCRIPTION
the package uses `RCurl` `rvest` and `dplyr`
they are added with `use_package()` to the `DESCRIPTION`